### PR TITLE
 Add getTotalEscrows and emergencyWithdraw functions to EscrowContract

### DIFF
--- a/src/academic-learning/EscrowContract.sol
+++ b/src/academic-learning/EscrowContract.sol
@@ -314,4 +314,13 @@ contract EscrowContract {
     function isExpired(uint256 escrowId) external view escrowExists(escrowId) returns (bool) {
         return block.timestamp > escrows[escrowId].deadline;
     }
+
+    /**
+     * @notice Get total number of escrows created
+     * @return Total number of escrows
+     * @dev Get total escrows created
+     */
+    function getTotalEscrows() external view returns (uint256) {
+        return escrowCounter;
+    }
 }

--- a/src/academic-learning/EscrowContract.sol
+++ b/src/academic-learning/EscrowContract.sol
@@ -323,4 +323,13 @@ contract EscrowContract {
     function getTotalEscrows() external view returns (uint256) {
         return escrowCounter;
     }
+
+    /**
+     * @notice Emergency withdrawal by owner
+     * @dev Emergency withdrawal by owner (only if contract needs to be upgraded)
+     */
+    function emergencyWithdraw() external {
+        require(msg.sender == owner, "Only owner");
+        payable(owner).transfer(address(this).balance);
+    }
 }


### PR DESCRIPTION
This PR adds two new functions to the EscrowContract:

1. `getTotalEscrows`: This function returns the total number of escrows created. It is a view function, meaning it does not modify the state of the contract and can be called without incurring gas costs.

2. `emergencyWithdraw`: This function allows the owner of the contract to withdraw all funds in case of an emergency, such as when the contract needs to be upgraded. It is only callable by the owner and transfers the entire balance of the contract to the owner's address.

**Motivation**:

The `getTotalEscrows` function provides a way to track the total number of escrows created, which can be useful for monitoring and analytics purposes. The `emergencyWithdraw` function provides a safety mechanism for the owner to recover funds in case the contract needs to be upgraded or if there is an issue with the contract's functionality.

**Changes:**

Added `getTotalEscrows` function to return the total number of escrows created
Added `emergencyWithdraw` function to allow owner to withdraw all funds in case of an emergency

**Specs:**

- `getTotalEscrows` function:
     - Returns uint256 representing the total number of escrows created
     - Is a view function, meaning it does not modify the state of the contract
- `emergencyWithdraw` function:
     - Transfers the entire balance of the contract to the owner's address
     - Is only callable by the owner
     - Requires the owner variable to be set to the correct address

**Testing:**

- `getTotalEscrows` function:
     - Test that the function returns the correct total number of escrows created
     - Test that the function does not modify the state of the contract
- `emergencyWithdraw` function:
     - Test that the function transfers the correct amount of funds to the owner's address
     - Test that the function is only callable by the owner
     - Test that the function reverts if called by a non-owner address

**Notes:**

- The emergencyWithdraw function should only be used in exceptional circumstances, such as when the contract needs to be upgraded or if there is an issue with the contract's functionality.
- The `owner` variable should be set to the correct address before deploying the contract.