### PR TITLE
Feat: Add burnFrom Function to SimpleToken Contract

### DIFF
--- a/src/tokencreation/CreateToken.sol
+++ b/src/tokencreation/CreateToken.sol
@@ -117,6 +117,13 @@ contract SimpleToken is ERC20, Ownable {
         _burn(msg.sender, amount);
     }
 
+    /**
+     * @notice Burns tokens from a specified account using allowance
+     * @dev Allows approved spenders to burn tokens from another account
+     *      Requires sufficient allowance from the account being burned from
+     * @param account The address to burn tokens from
+     * @param amount The number of tokens to burn (in wei units)
+     */
     function burnFrom(address account, uint256 amount) public {
     _spendAllowance(account, msg.sender, amount);
     _burn(account, amount);


### PR DESCRIPTION
## Summary
This PR adds a `burnFrom` function to the `SimpleToken` contract, enabling approved spenders to burn tokens from another account's balance using the allowance mechanism.

## Changes Made
- ✅ Added `burnFrom(address account, uint256 amount)` function
- ✅ Implemented proper allowance checks using `_spendAllowance`
- ✅ Added comprehensive NatSpec documentation

## Technical Details

### Function Signature
```solidity
function burnFrom(address account, uint256 amount) public
```

### Functionality
- Allows approved spenders to burn tokens from a specified account
- Utilizes the existing ERC20 allowance system for authorization
- Decrements both the account's balance and the caller's allowance
- Follows standard ERC20 patterns for secure token operations

### Security Considerations
- ✅ Proper allowance validation through `_spendAllowance`
- ✅ Prevents unauthorized burning of tokens
- ✅ Maintains ERC20 compliance and security standards

## Documentation
Added full NatSpec documentation including:
- `@notice` - User-friendly function description
- `@dev` - Technical implementation details
- `@param` - Parameter descriptions with units

## Files Modified
- `src/tokencreation/CreateToken.sol` (+12 lines)

## Commits
- `Feat: Add burnFrom Func`
- `Feat: Add Full Natspec For burnFrom Func`

---

**Ready for review** 🚀