### PR TITLE
feat: Add `getTask` and `getSubmission` external view functions

### DIFF
--- a/src/academic-learning/TaskBounty.sol
+++ b/src/academic-learning/TaskBounty.sol
@@ -190,4 +190,13 @@ contract TaskBounty {
     function getTask(uint256 _taskId) external view taskExists(_taskId) returns (Task memory) {
         return tasks[_taskId];
     }
+
+    function getSubmission(uint256 _submissionId)
+        external
+        view
+        submissionExists(_submissionId)
+        returns (Submission memory)
+    {
+        return submissions[_submissionId];
+    }
 }

--- a/src/academic-learning/TaskBounty.sol
+++ b/src/academic-learning/TaskBounty.sol
@@ -182,6 +182,11 @@ contract TaskBounty {
         emit TaskDeactivated(_taskId, msg.sender);
     }
 
+    /**
+     * @dev Get task details
+     * @param _taskId ID of the task
+     * @return Task struct
+     */
     function getTask(uint256 _taskId) external view taskExists(_taskId) returns (Task memory) {
         return tasks[_taskId];
     }

--- a/src/academic-learning/TaskBounty.sol
+++ b/src/academic-learning/TaskBounty.sol
@@ -181,4 +181,8 @@ contract TaskBounty {
 
         emit TaskDeactivated(_taskId, msg.sender);
     }
+
+    function getTask(uint256 _taskId) external view taskExists(_taskId) returns (Task memory) {
+        return tasks[_taskId];
+    }
 }

--- a/src/academic-learning/TaskBounty.sol
+++ b/src/academic-learning/TaskBounty.sol
@@ -191,6 +191,11 @@ contract TaskBounty {
         return tasks[_taskId];
     }
 
+    /**
+     * @dev Get submission details
+     * @param _submissionId ID of the submission
+     * @return Submission struct
+     */
     function getSubmission(uint256 _submissionId)
         external
         view


### PR DESCRIPTION
## Summary
This PR introduces two new external **view functions** to the `TaskBounty` contract, enabling direct retrieval of task and submission details. These read-only methods improve contract usability, making it easier for off-chain clients (such as dApps, frontends, and indexers) to fetch information without needing to parse events or maintain local state.

---

## Changes
- **Added `getTask(uint256 _taskId)`**
  - Returns a full `Task` struct for a given task ID.
  - Restricted by `taskExists` modifier to ensure validity.
  - Provides all task properties, including creator, solver, status, reward, and metadata.

- **Added `getSubmission(uint256 _submissionId)`**
  - Returns a full `Submission` struct for a given submission ID.
  - Restricted by `submissionExists` modifier to prevent invalid lookups.
  - Exposes submitter details, solution, acceptance status, and references to parent task.

- **Natspec Documentation**
  - Added clear `@dev` and `@param` descriptions for both functions.
  - Includes explicit `@return` comments describing the returned struct.

---

## Rationale
Previously, off-chain consumers of the smart contract had no direct way to query tasks or submissions by ID beyond event logs. These new view functions:
- Simplify frontend integration for displaying task/submission details.
- Improve developer experience by exposing data directly.
- Maintain immutability and safety since they are read-only functions.

---

## Verification
- Compiled successfully with `forge build`.
- Code formatted with `forge fmt`.
- Confirmed:
  - `getTask` correctly returns task state after creation and updates.
  - `getSubmission` correctly returns submission state after solution submission and acceptance.

---

## Next Steps
- [ ] Add Foundry unit tests for `getTask` and `getSubmission`.
- [ ] Integrate with frontend to display live task/submission data.
- [ ] Expand to include array-based getters (e.g., `getAllTasks`) for batch queries if needed.

---
